### PR TITLE
Add stringr as docker requirement

### DIFF
--- a/src/civ6_save_renderer/plot_map/config.vsh.yaml
+++ b/src/civ6_save_renderer/plot_map/config.vsh.yaml
@@ -50,6 +50,7 @@ platforms:
           - ggplot2
           - tibble
           - processx
+          - stringr
         github:
           - rcannood/civ6saves
   - type: nextflow


### PR DESCRIPTION
Add `stringr` as a requirement for the plot_map component